### PR TITLE
feat: Show dimensions in mm next to each crop size option

### DIFF
--- a/src/features/crop/Crop.tsx
+++ b/src/features/crop/Crop.tsx
@@ -80,11 +80,16 @@ const Crop = () => {
                         <SelectValue placeholder="Select target size" />
                     </SelectTrigger>
                     <SelectContent>
-                        {imageConfigArr.map(({ name, descripton }) => (
-                            <SelectItem key={name} value={name} className="text-xs">
-                                {`${name}${descripton ? ' (' + descripton + ')' : ''}`}
-                            </SelectItem>
-                        ))}
+                        {imageConfigArr.map(({ name, width, height, unit }) => {
+                            const wMm = unit === 'cm' ? Math.round(width * 10) : unit === 'inch' ? Math.round(width * 25.4) : width;
+                            const hMm = unit === 'cm' ? Math.round(height * 10) : unit === 'inch' ? Math.round(height * 25.4) : height;
+                            return (
+                                <SelectItem key={name} value={name} className="text-xs flex justify-between">
+                                    <span>{name}</span>
+                                    <span className="ml-3 text-muted-foreground/60 tabular-nums">{wMm}×{hMm}mm</span>
+                                </SelectItem>
+                            );
+                        })}
                     </SelectContent>
                 </Select>
             </div>


### PR DESCRIPTION
## Summary
- Each item in the Target Size dropdown now shows its physical dimensions in mm (e.g. `25×35mm`) as muted text to the right of the name
- cm values are multiplied by 10, inch values are converted via ×25.4, both rounded to nearest mm

## Test plan
- [ ] Open the Crop view and expand the Target Size dropdown
- [ ] Verify each option shows `W×Hmm` next to its name
- [ ] Check that inch-based sizes (US Visa) convert correctly (51×51mm)
- [ ] Confirm light and dark themes both render the muted dimension text legibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)