### PR TITLE
feat: Add custom photo and paper dimension inputs

### DIFF
--- a/src/core/imageHelpers.ts
+++ b/src/core/imageHelpers.ts
@@ -31,7 +31,6 @@ export async function getCroppedImg(imageSrc: string, pixelCrop: Area) {
     return { croppedImage, rawImageUrl };
 }
 
-
 export function generateCollate(
     patternImage: HTMLImageElement,
     targetImageConfig: IImageConfig,

--- a/src/features/collate/Collate.tsx
+++ b/src/features/collate/Collate.tsx
@@ -1,6 +1,7 @@
 import { Download, Loader2, Check } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
 import photoPaperConfigRaw from '../../config/photo-paper-config.json';
@@ -13,18 +14,50 @@ const photoPaperConfigArr = photoPaperConfigRaw as IImageConfig[];
 
 const BG_OPTIONS = [{ value: '#fff', label: 'White', bgClass: 'bg-white', borderClass: 'border border-border' }];
 
+const CUSTOM_NAME = 'Custom';
+
+type DimUnit = 'mm' | 'inch';
+
+function toInternalConfig(w: number, h: number, unit: DimUnit, backgroundColor: string): IImageConfig {
+    return {
+        name: CUSTOM_NAME,
+        width: unit === 'mm' ? w / 10 : w,
+        height: unit === 'mm' ? h / 10 : h,
+        unit: unit === 'mm' ? 'cm' : 'inch',
+        backgroundColor,
+    };
+}
+
 const Collate = () => {
     const { uploadImage, photoPaper, setPhotoPaper } = useStore();
     const { loading, downloadPrint } = useImageCollate();
 
     const [backgroundColor, setBackgroundColor] = useState('#fff');
 
+    const [customUnit, setCustomUnit] = useState<DimUnit>('mm');
+    const [customW, setCustomW] = useState('');
+    const [customH, setCustomH] = useState('');
+
+    const isCustom = photoPaper?.name === CUSTOM_NAME;
+
     useEffect(() => {
         const defaultPaper = photoPaperConfigArr.find(c => c.name === '6寸(4R)') ?? photoPaperConfigArr[0];
         setPhotoPaper({ ...defaultPaper, backgroundColor });
     }, []);
 
+    const applyCustomDims = (w: string, h: string, unit: DimUnit, bgColor: string) => {
+        const wv = parseFloat(w);
+        const hv = parseFloat(h);
+        if (wv > 0 && hv > 0) {
+            setPhotoPaper(toInternalConfig(wv, hv, unit, bgColor));
+        }
+    };
+
     const onPhotoPaperChange = (value: string) => {
+        if (value === CUSTOM_NAME) {
+            setPhotoPaper({ name: CUSTOM_NAME, width: 0, height: 0, unit: 'cm', backgroundColor });
+            return;
+        }
         const selectedConfig = photoPaperConfigArr.find(config => config.name === value);
         if (selectedConfig) {
             setPhotoPaper({ ...selectedConfig, backgroundColor });
@@ -65,8 +98,62 @@ const Collate = () => {
                                             {`${name} ${unit}`}
                                         </SelectItem>
                                     ))}
+                                    <SelectItem value={CUSTOM_NAME} className="text-xs">
+                                        <span>{CUSTOM_NAME}</span>
+                                        <span className="ml-3 text-muted-foreground/60">enter dimensions</span>
+                                    </SelectItem>
                                 </SelectContent>
                             </Select>
+
+                            {isCustom && (
+                                <div className="mt-2 space-y-2">
+                                    <div className="flex gap-1">
+                                        {(['mm', 'inch'] as const).map(u => (
+                                            <button
+                                                key={u}
+                                                onClick={() => {
+                                                    setCustomUnit(u);
+                                                    applyCustomDims(customW, customH, u, backgroundColor);
+                                                }}
+                                                className={cn(
+                                                    'px-2.5 py-1 text-[10px] tracking-[0.15em] uppercase border transition-colors',
+                                                    customUnit === u
+                                                        ? 'border-primary text-primary bg-primary/5'
+                                                        : 'border-border/50 text-muted-foreground hover:border-border'
+                                                )}
+                                            >
+                                                {u}
+                                            </button>
+                                        ))}
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <Input
+                                            type="number"
+                                            placeholder="W"
+                                            value={customW}
+                                            min={1}
+                                            className="h-8 text-xs w-20"
+                                            onChange={e => {
+                                                setCustomW(e.target.value);
+                                                applyCustomDims(e.target.value, customH, customUnit, backgroundColor);
+                                            }}
+                                        />
+                                        <span className="text-muted-foreground/50 text-xs">×</span>
+                                        <Input
+                                            type="number"
+                                            placeholder="H"
+                                            value={customH}
+                                            min={1}
+                                            className="h-8 text-xs w-20"
+                                            onChange={e => {
+                                                setCustomH(e.target.value);
+                                                applyCustomDims(customW, e.target.value, customUnit, backgroundColor);
+                                            }}
+                                        />
+                                        <span className="text-[10px] text-muted-foreground/50">{customUnit}</span>
+                                    </div>
+                                </div>
+                            )}
                         </div>
 
                         {/* Background swatches */}

--- a/src/features/collate/Collate.tsx
+++ b/src/features/collate/Collate.tsx
@@ -9,24 +9,11 @@ import useImageCollate from './hooks/useImageCollate';
 import { useStore } from '../../stores/store';
 import { IImageConfig } from '../../types';
 import StyledPaper from '../../components/StyledPaper';
+import { CUSTOM_NAME, DimUnit, toInternalConfig } from '../customDimensions';
 
 const photoPaperConfigArr = photoPaperConfigRaw as IImageConfig[];
 
 const BG_OPTIONS = [{ value: '#fff', label: 'White', bgClass: 'bg-white', borderClass: 'border border-border' }];
-
-const CUSTOM_NAME = 'Custom';
-
-type DimUnit = 'mm' | 'inch';
-
-function toInternalConfig(w: number, h: number, unit: DimUnit, backgroundColor: string): IImageConfig {
-    return {
-        name: CUSTOM_NAME,
-        width: unit === 'mm' ? w / 10 : w,
-        height: unit === 'mm' ? h / 10 : h,
-        unit: unit === 'mm' ? 'cm' : 'inch',
-        backgroundColor,
-    };
-}
 
 const Collate = () => {
     const { uploadImage, photoPaper, setPhotoPaper } = useStore();
@@ -45,13 +32,15 @@ const Collate = () => {
         setPhotoPaper({ ...defaultPaper, backgroundColor });
     }, []);
 
-    const applyCustomDims = (w: string, h: string, unit: DimUnit, bgColor: string) => {
-        const wv = parseFloat(w);
-        const hv = parseFloat(h);
-        if (wv > 0 && hv > 0) {
-            setPhotoPaper(toInternalConfig(wv, hv, unit, bgColor));
-        }
-    };
+    // Debounce custom dim changes so canvas work only fires after typing stops
+    useEffect(() => {
+        if (!isCustom) return;
+        const wv = parseFloat(customW);
+        const hv = parseFloat(customH);
+        if (!(wv > 0 && hv > 0)) return;
+        const t = setTimeout(() => setPhotoPaper(toInternalConfig(wv, hv, customUnit, backgroundColor)), 400);
+        return () => clearTimeout(t);
+    }, [customW, customH, customUnit, isCustom]);
 
     const onPhotoPaperChange = (value: string) => {
         if (value === CUSTOM_NAME) {
@@ -111,10 +100,7 @@ const Collate = () => {
                                         {(['mm', 'inch'] as const).map(u => (
                                             <button
                                                 key={u}
-                                                onClick={() => {
-                                                    setCustomUnit(u);
-                                                    applyCustomDims(customW, customH, u, backgroundColor);
-                                                }}
+                                                onClick={() => setCustomUnit(u)}
                                                 className={cn(
                                                     'px-2.5 py-1 text-[10px] tracking-[0.15em] uppercase border transition-colors',
                                                     customUnit === u
@@ -133,10 +119,7 @@ const Collate = () => {
                                             value={customW}
                                             min={1}
                                             className="h-8 text-xs w-20"
-                                            onChange={e => {
-                                                setCustomW(e.target.value);
-                                                applyCustomDims(e.target.value, customH, customUnit, backgroundColor);
-                                            }}
+                                            onChange={e => setCustomW(e.target.value)}
                                         />
                                         <span className="text-muted-foreground/50 text-xs">×</span>
                                         <Input
@@ -145,10 +128,7 @@ const Collate = () => {
                                             value={customH}
                                             min={1}
                                             className="h-8 text-xs w-20"
-                                            onChange={e => {
-                                                setCustomH(e.target.value);
-                                                applyCustomDims(customW, e.target.value, customUnit, backgroundColor);
-                                            }}
+                                            onChange={e => setCustomH(e.target.value)}
                                         />
                                         <span className="text-[10px] text-muted-foreground/50">{customUnit}</span>
                                     </div>

--- a/src/features/crop/Crop.tsx
+++ b/src/features/crop/Crop.tsx
@@ -12,23 +12,12 @@ import { useStore } from '../../stores/store';
 import { IImageConfig } from '../../types';
 import { downloadImage } from '../../utils';
 import StyledPaper from '../../components/StyledPaper';
+import { CUSTOM_NAME, DimUnit, toInternalConfig } from '../customDimensions';
 
 const imageConfigArr = imageConfigRaw as IImageConfig[];
 
 const ZOOM_MIN = 1;
 const ZOOM_MAX = 3;
-const CUSTOM_NAME = 'Custom';
-
-type DimUnit = 'mm' | 'inch';
-
-function toInternalConfig(w: number, h: number, unit: DimUnit): IImageConfig {
-    return {
-        name: CUSTOM_NAME,
-        width: unit === 'mm' ? w / 10 : w,
-        height: unit === 'mm' ? h / 10 : h,
-        unit: unit === 'mm' ? 'cm' : 'inch',
-    };
-}
 
 const Crop = () => {
     const croppedImageRaw = useRef<string>('');
@@ -36,30 +25,27 @@ const Crop = () => {
 
     const [crop, setLocalCrop] = useState({ x: 0, y: 0 });
     const [zoom, setZoom] = useState(ZOOM_MIN);
-    const [cropRatio, setCropRatio] = useState(0);
 
     const [customUnit, setCustomUnit] = useState<DimUnit>('mm');
     const [customW, setCustomW] = useState('');
     const [customH, setCustomH] = useState('');
 
     const isCustom = targetImage?.name === CUSTOM_NAME;
+    const cropRatio = targetImage && targetImage.width > 0 ? targetImage.width / targetImage.height : undefined;
 
     useEffect(() => {
-        const selectedConfig = imageConfigArr[0];
-        const ratio = selectedConfig.width / selectedConfig.height;
-        setCropRatio(ratio);
-        setTargetImage(selectedConfig);
+        setTargetImage(imageConfigArr[0]);
     }, []);
 
-    const applyCustomDims = (w: string, h: string, unit: DimUnit) => {
-        const wv = parseFloat(w);
-        const hv = parseFloat(h);
-        if (wv > 0 && hv > 0) {
-            const cfg = toInternalConfig(wv, hv, unit);
-            setCropRatio(cfg.width / cfg.height);
-            setTargetImage(cfg);
-        }
-    };
+    // Debounce custom dim changes so canvas work only fires after typing stops
+    useEffect(() => {
+        if (!isCustom) return;
+        const wv = parseFloat(customW);
+        const hv = parseFloat(customH);
+        if (!(wv > 0 && hv > 0)) return;
+        const t = setTimeout(() => setTargetImage(toInternalConfig(wv, hv, customUnit)), 400);
+        return () => clearTimeout(t);
+    }, [customW, customH, customUnit, isCustom]);
 
     const onCropComplete = (croppedArea: Area, croppedAreaPixels: Area) => {
         setCrop(croppedAreaPixels);
@@ -79,8 +65,6 @@ const Crop = () => {
         }
         const selectedConfig = imageConfigArr.find(config => config.name === value);
         if (selectedConfig) {
-            const ratio = selectedConfig.width / selectedConfig.height;
-            setCropRatio(ratio);
             setTargetImage(selectedConfig);
         }
     };
@@ -145,10 +129,7 @@ const Crop = () => {
                             {(['mm', 'inch'] as const).map(u => (
                                 <button
                                     key={u}
-                                    onClick={() => {
-                                        setCustomUnit(u);
-                                        applyCustomDims(customW, customH, u);
-                                    }}
+                                    onClick={() => setCustomUnit(u)}
                                     className={cn(
                                         'px-2.5 py-1 text-[10px] tracking-[0.15em] uppercase border transition-colors',
                                         customUnit === u
@@ -167,10 +148,7 @@ const Crop = () => {
                                 value={customW}
                                 min={1}
                                 className="h-8 text-xs w-20"
-                                onChange={e => {
-                                    setCustomW(e.target.value);
-                                    applyCustomDims(e.target.value, customH, customUnit);
-                                }}
+                                onChange={e => setCustomW(e.target.value)}
                             />
                             <span className="text-muted-foreground/50 text-xs">×</span>
                             <Input
@@ -179,10 +157,7 @@ const Crop = () => {
                                 value={customH}
                                 min={1}
                                 className="h-8 text-xs w-20"
-                                onChange={e => {
-                                    setCustomH(e.target.value);
-                                    applyCustomDims(customW, e.target.value, customUnit);
-                                }}
+                                onChange={e => setCustomH(e.target.value)}
                             />
                             <span className="text-[10px] text-muted-foreground/50">{customUnit}</span>
                         </div>
@@ -197,7 +172,7 @@ const Crop = () => {
                     crop={crop}
                     onCropChange={point => setLocalCrop(point)}
                     zoom={zoom}
-                    aspect={cropRatio || undefined}
+                    aspect={cropRatio}
                     minZoom={ZOOM_MIN}
                     maxZoom={ZOOM_MAX}
                     onZoomChange={z => setZoom(z)}

--- a/src/features/crop/Crop.tsx
+++ b/src/features/crop/Crop.tsx
@@ -2,8 +2,10 @@ import { Download, RotateCcw, ZoomIn, ZoomOut } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import Cropper, { Area } from 'react-easy-crop';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Slider } from '@/components/ui/slider';
+import { cn } from '@/lib/utils';
 import imageConfigRaw from '../../config/target-image-config.json';
 import { getCroppedImg } from '../../core/imageHelpers';
 import { useStore } from '../../stores/store';
@@ -15,6 +17,18 @@ const imageConfigArr = imageConfigRaw as IImageConfig[];
 
 const ZOOM_MIN = 1;
 const ZOOM_MAX = 3;
+const CUSTOM_NAME = 'Custom';
+
+type DimUnit = 'mm' | 'inch';
+
+function toInternalConfig(w: number, h: number, unit: DimUnit): IImageConfig {
+    return {
+        name: CUSTOM_NAME,
+        width: unit === 'mm' ? w / 10 : w,
+        height: unit === 'mm' ? h / 10 : h,
+        unit: unit === 'mm' ? 'cm' : 'inch',
+    };
+}
 
 const Crop = () => {
     const croppedImageRaw = useRef<string>('');
@@ -24,12 +38,28 @@ const Crop = () => {
     const [zoom, setZoom] = useState(ZOOM_MIN);
     const [cropRatio, setCropRatio] = useState(0);
 
+    const [customUnit, setCustomUnit] = useState<DimUnit>('mm');
+    const [customW, setCustomW] = useState('');
+    const [customH, setCustomH] = useState('');
+
+    const isCustom = targetImage?.name === CUSTOM_NAME;
+
     useEffect(() => {
         const selectedConfig = imageConfigArr[0];
         const ratio = selectedConfig.width / selectedConfig.height;
         setCropRatio(ratio);
         setTargetImage(selectedConfig);
     }, []);
+
+    const applyCustomDims = (w: string, h: string, unit: DimUnit) => {
+        const wv = parseFloat(w);
+        const hv = parseFloat(h);
+        if (wv > 0 && hv > 0) {
+            const cfg = toInternalConfig(wv, hv, unit);
+            setCropRatio(cfg.width / cfg.height);
+            setTargetImage(cfg);
+        }
+    };
 
     const onCropComplete = (croppedArea: Area, croppedAreaPixels: Area) => {
         setCrop(croppedAreaPixels);
@@ -43,6 +73,10 @@ const Crop = () => {
     };
 
     const onTargetImageChange = (value: string) => {
+        if (value === CUSTOM_NAME) {
+            setTargetImage({ name: CUSTOM_NAME, width: 0, height: 0, unit: 'cm' });
+            return;
+        }
         const selectedConfig = imageConfigArr.find(config => config.name === value);
         if (selectedConfig) {
             const ratio = selectedConfig.width / selectedConfig.height;
@@ -98,8 +132,62 @@ const Crop = () => {
                                 </SelectItem>
                             );
                         })}
+                        <SelectItem value={CUSTOM_NAME} className="text-xs">
+                            <span>{CUSTOM_NAME}</span>
+                            <span className="ml-3 text-muted-foreground/60">enter dimensions</span>
+                        </SelectItem>
                     </SelectContent>
                 </Select>
+
+                {isCustom && (
+                    <div className="mt-2 space-y-2">
+                        <div className="flex gap-1">
+                            {(['mm', 'inch'] as const).map(u => (
+                                <button
+                                    key={u}
+                                    onClick={() => {
+                                        setCustomUnit(u);
+                                        applyCustomDims(customW, customH, u);
+                                    }}
+                                    className={cn(
+                                        'px-2.5 py-1 text-[10px] tracking-[0.15em] uppercase border transition-colors',
+                                        customUnit === u
+                                            ? 'border-primary text-primary bg-primary/5'
+                                            : 'border-border/50 text-muted-foreground hover:border-border'
+                                    )}
+                                >
+                                    {u}
+                                </button>
+                            ))}
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <Input
+                                type="number"
+                                placeholder="W"
+                                value={customW}
+                                min={1}
+                                className="h-8 text-xs w-20"
+                                onChange={e => {
+                                    setCustomW(e.target.value);
+                                    applyCustomDims(e.target.value, customH, customUnit);
+                                }}
+                            />
+                            <span className="text-muted-foreground/50 text-xs">×</span>
+                            <Input
+                                type="number"
+                                placeholder="H"
+                                value={customH}
+                                min={1}
+                                className="h-8 text-xs w-20"
+                                onChange={e => {
+                                    setCustomH(e.target.value);
+                                    applyCustomDims(customW, e.target.value, customUnit);
+                                }}
+                            />
+                            <span className="text-[10px] text-muted-foreground/50">{customUnit}</span>
+                        </div>
+                    </div>
+                )}
             </div>
 
             {/* Crop area */}
@@ -109,7 +197,7 @@ const Crop = () => {
                     crop={crop}
                     onCropChange={point => setLocalCrop(point)}
                     zoom={zoom}
-                    aspect={cropRatio}
+                    aspect={cropRatio || undefined}
                     minZoom={ZOOM_MIN}
                     maxZoom={ZOOM_MAX}
                     onZoomChange={z => setZoom(z)}

--- a/src/features/customDimensions.ts
+++ b/src/features/customDimensions.ts
@@ -1,0 +1,15 @@
+import { IImageConfig } from '../types';
+
+export const CUSTOM_NAME = 'Custom';
+
+export type DimUnit = 'mm' | 'inch';
+
+export function toInternalConfig(w: number, h: number, unit: DimUnit, backgroundColor?: string): IImageConfig {
+    return {
+        name: CUSTOM_NAME,
+        width: unit === 'mm' ? w / 10 : w,
+        height: unit === 'mm' ? h / 10 : h,
+        unit: unit === 'mm' ? 'cm' : 'inch',
+        ...(backgroundColor !== undefined && { backgroundColor }),
+    };
+}


### PR DESCRIPTION
Closes #25

## Summary
- **Target Size** dropdown (Crop): new **Custom** option at the bottom — reveals a mm/inch unit toggle and W × H number inputs; cropper aspect ratio updates live as you type
- **Paper Size** dropdown (Arrange): same Custom option — collate layout recalculates live from the entered dimensions
- Both unit systems (mm and inch) are supported; mm is stored internally as cm, inch as inch, matching the existing `IImageConfig` schema

## Test plan
- [ ] Crop → Target Size → Custom: toggle mm/inch, type W and H, verify cropper aspect ratio changes
- [ ] Arrange → Paper Size → Custom: type W and H, verify canvas layout updates
- [ ] Switching back to a preset from Custom restores normal behavior
- [ ] `npm run lint && npm run format:check && npm run build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)